### PR TITLE
adding feature issue option

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,36 @@
+name: Feature request or enhancement
+description: Open a new issue to describe and request a new feature or enhancement. These will be auto-labeled with _enhancement_. Be sure to provide an informative title.
+labels: ["enhancement"]
+body: 
+- type: textarea 
+  id: summary
+  attributes:
+    label: Feature or enhancement
+    description: Please describe what you would like to be able to do or see. Consider telling a story, e.g. first I do x, then y, then I see z.
+    placeholder: E.g. When I am at X, then I need Y, and when I click, then I will see Z.
+  validations:
+    required: true 
+- type: input 
+  id: summary_target
+  attributes:
+    label: Location
+    description: Stepping back, where should this feature be found? Providing a URL path can help (e.g. /taxon_names/123).
+    placeholder: Nomenclature Panel
+  validations:
+    required: true 
+- type: textarea 
+  id: figures
+  attributes:
+    label: Screenshot, napkin sketch of interface, or conceptual description
+    description: Provide drawings or screenshots mocking-up (illustrating) your feature, or feature progression.  
+    placeholder: Drag/drop your image(s) here
+  validations:
+    required: false
+- type: input 
+  id: summary_x
+  attributes:
+    label: Your role 
+    description: Who are you, i.e. in what role are you making this feature request? 
+    placeholder: Graduate student biologist 
+  validations:
+    required: false 


### PR DESCRIPTION
This feature issue option will need review and editing before merging into the production repository.

Maybe I need to submit these as "Convert to Draft" (which I see in the right menu bar .. but it is a feature of GitHub I have not used ... so hesitant to click on it.