### PR TITLE
Adjust Count computation in Keys panel to be # of keys

### DIFF
--- a/src/modules/otus/components/Panel/PanelKeys/PanelKeys.vue
+++ b/src/modules/otus/components/Panel/PanelKeys/PanelKeys.vue
@@ -71,7 +71,9 @@ const count = computed(
   () =>
     []
       .concat(...Object.values(keys.value.to), ...Object.values(keys.value.in))
-      .filter((item) => Object.keys(item).length).length
+      .map((h) => Object.keys(h))
+      .flat()
+      .length
 )
 
 onMounted(() => {


### PR DESCRIPTION
Previously it was "number of sections (from matrix to, matrix in, lead to, lead in) that have a key".

This is related to, but independent of, https://github.com/SpeciesFileGroup/taxonworks/pull/4372