### PR TITLE
Codex fix for server crash on in-place api.yml edit in some enviros

### DIFF
--- a/src/plugins/vite/restart.js
+++ b/src/plugins/vite/restart.js
@@ -1,10 +1,33 @@
 import path from 'node:path'
 import picomatch from 'picomatch'
 
+const GLOB_CHARS = /[*?[\]{}()!+]/
+
+function getWatchTarget(pattern) {
+  const normalizedPattern = pattern.replace(/\\/g, '/')
+  const segments = normalizedPattern.split('/')
+  const staticSegments = []
+
+  for (const segment of segments) {
+    if (!segment || GLOB_CHARS.test(segment)) {
+      break
+    }
+
+    staticSegments.push(segment)
+  }
+
+  if (staticSegments.length === 0) {
+    return '.'
+  }
+
+  return staticSegments.join('/')
+}
+
 export default function ViteRestart({ dir }) {
   const root = process.cwd()
   const patterns = Array.isArray(dir) ? dir : [dir]
   const isMatch = picomatch(patterns, { dot: true })
+  const watchTargets = [...new Set(patterns.map(getWatchTarget))]
 
   return {
     name: 'vite-restart',
@@ -17,8 +40,7 @@ export default function ViteRestart({ dir }) {
           server.restart()
         }
       }
-
-      server.watcher.add(dir)
+      server.watcher.add(watchTargets)
       server.watcher.on('change', handleChange)
     }
   }


### PR DESCRIPTION
This happened on my fedora 43 system every time, but other people on other systems never see it at all.

STR:
* Clone taxonpages fresh
* Do setup from the README
* `npm run dev`
* Do `cp /tmp/api.yml config/`, see server refresh, as expected
* Edit api.yml with `vi config/api.yml` On save see the server crash with
```
  VITE v7.3.1  ready in 449 ms

  ➜  Local:   http://localhost:5173/taxonpages/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
5:57:04 PM [vite] server restarted.
5:58:40 PM [vite] server restarted. (x2)
file:///home/klein/sandbox/t/taxonpages/node_modules/vite/dist/node/chunks/config.js:13008
				cont.watcher.close();
				             ^

TypeError: Cannot read properties of undefined (reading 'close')
    at file:///home/klein/sandbox/t/taxonpages/node_modules/vite/dist/node/chunks/config.js:13008:18
    at file:///home/klein/sandbox/t/taxonpages/node_modules/vite/dist/node/chunks/config.js:14001:21
    at Array.forEach (<anonymous>)
    at file:///home/klein/sandbox/t/taxonpages/node_modules/vite/dist/node/chunks/config.js:14000:53
    at Map.forEach (<anonymous>)
    at FSWatcher.close (file:///home/klein/sandbox/t/taxonpages/node_modules/vite/dist/node/chunks/config.js:14000:18)
    at closeServer (file:///home/klein/sandbox/t/taxonpages/node_modules/vite/dist/node/chunks/config.js:25409:12)
    at Object.close (file:///home/klein/sandbox/t/taxonpages/node_modules/vite/dist/node/chunks/config.js:25506:50)
    at restartServer (file:///home/klein/sandbox/t/taxonpages/node_modules/vite/dist/node/chunks/config.js:25778:16)

Node.js v22.22.0

```

This is Codex's patch to go with its analysis:
```
• Root cause is in src/plugins/vite/restart.js: it passes a glob (config/**/*.yml) directly into server.watcher.add(...).
  With Vite 7 / chokidar 4, that can break server restart cleanup and produce your exact crash (cont.watcher.close() / undefined).

  I patched it to watch concrete paths and keep glob matching only in picomatch.

  Changed file:

  - src/plugins/vite/restart.js:4
  - src/plugins/vite/restart.js:6
  - src/plugins/vite/restart.js:30
  - src/plugins/vite/restart.js:43

  What changed:

  - Added getWatchTarget() to convert patterns like config/**/*.yml -> config
  - server.watcher.add(dir) -> server.watcher.add(watchTargets)

  I reproduced your failure (Node v22.22.0) with an atomic-style edit, then verified after the patch:

  - edit config/api.yml
  - Vite restarts
  - no TypeError crash

  If you want, I can also format this as a small PR-style patch message for your developer to apply directly.

› say more about the version dependance, how do you know it's a version issue?

• It’s very likely version-dependent because the failure sits exactly at the boundary where watcher behavior changed:

  1. Your repo is on vite@7.3.1 (from package.json), and the lockfile includes chokidar@4.0.3.
  2. The custom plugin does this:
      - server.watcher.add('config/**/*.yml') (a glob)
  3. In newer watcher stacks, glob semantics changed and Vite’s internal watcher container can end up with entries that don’t have a real underlying watcher object.
  4. The crash is during Vite restart cleanup, not your app logic:
      - cont.watcher.close() where cont.watcher is undefined
  5. Changing only that one behavior (watch real paths like config, then filter with picomatch) fixes the crash with everything else unchanged, which is strong isolation evidence.

  Why your developer might not reproduce:

  - Different Node version (you’re on v22.22.0)
  - Different lockfile resolution / transitive deps
  - Different edit/write pattern from their editor (atomic rename vs in-place write), which triggers different watcher events

  So I can’t prove “Vite 7 is broken in all environments,” but I can say the bug is caused by relying on old glob-watch assumptions that no longer hold consistently in your current Vite/chokidar/runtime combination.
```