### PR TITLE
Fix Type panel

### DIFF
--- a/src/modules/otus/components/Panel/PanelTypeDesignation/PanelTypeDesignation.vue
+++ b/src/modules/otus/components/Panel/PanelTypeDesignation/PanelTypeDesignation.vue
@@ -29,9 +29,9 @@ const typeDesignation = computed(
 )
 const typeDesignationLabel = computed(() =>
   [
-    typeDesignation.value.subject_object_tag || '',
+    typeDesignation.value.subject_name || '',
     typeDesignation.value.subject_status_tag || '',
-    typeDesignation.value.object_object_tag || ''
+    typeDesignation.value.object_name || ''
   ].join(' ')
 )
 </script>

--- a/src/modules/otus/components/Panel/PanelTypeDesignation/PanelTypeDesignation.vue
+++ b/src/modules/otus/components/Panel/PanelTypeDesignation/PanelTypeDesignation.vue
@@ -5,14 +5,23 @@
       <PanelDropdown panel-key="panel:type" />
     </VCardHeader>
     <VCardContent class="text-sm">
-      <p v-html="typeDesignationLabel" />
+      <p v-if="typeDesignation.subject_name">
+        <RouterLink
+          v-if="subjectOtuId"
+          :to="{ name: 'otus-id', params: { id: subjectOtuId } }"
+          class="text-secondary hover:underline"
+        ><em v-if="subjectItalic">{{ subjectParsed.italic }}</em><template v-else>{{ subjectParsed.italic }}</template></RouterLink>
+        <em v-else-if="subjectItalic">{{ subjectParsed.italic }}</em>
+        <template v-else>{{ subjectParsed.italic }}</template><span v-html="labelSuffix" />
+      </p>
     </VCardContent>
   </VCard>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useOtuStore } from '@/modules/otus/store/store'
+import { makeAPIRequest } from '@/utils/request'
 import PanelDropdown from '../PanelDropdown.vue'
 
 const props = defineProps({
@@ -27,11 +36,81 @@ const store = useOtuStore()
 const typeDesignation = computed(
   () => store.taxon?.type_taxon_name_relationship || {}
 )
-const typeDesignationLabel = computed(() =>
-  [
-    typeDesignation.value.subject_name || '',
-    typeDesignation.value.subject_status_tag || '',
-    typeDesignation.value.object_name || ''
-  ].join(' ')
+
+// The relationship type string encodes the object's rank:
+// e.g. "TaxonNameRelationship::Typification::Genus::Original::OriginalDesignation" → "Genus"
+const typLevel = computed(() => {
+  const match = (typeDesignation.value.type || '').match(/Typification::(\w+)::/)
+  return match ? match[1] : null
+})
+
+// Genus and species group names are italic; family group and above are not.
+const GENUS_GROUP  = ['Genus', 'Subgenus']
+const FAMILY_GROUP = ['Family', 'Subfamily', 'Tribe', 'Subtribe', 'Supertribe']
+
+// Subject is one rank below the object. It is italic when it belongs to genus or species group.
+const subjectItalic = computed(() =>
+  GENUS_GROUP.includes(typLevel.value) || FAMILY_GROUP.includes(typLevel.value)
+)
+// Object is italic only when it is genus group.
+const objectItalic = computed(() =>
+  GENUS_GROUP.includes(typLevel.value)
+)
+
+// Split "Genus species Author, Year" into the italicisable name and plain authorship.
+function splitName(name) {
+  const words = (name || '').trim().split(/\s+/)
+  let i = 1
+  while (i < words.length) {
+    const w = words[i]
+    if (/^[a-z]/.test(w)) { i++; continue }
+    if (/^\(/.test(w) && /^[a-z]/.test(words[i + 1] || '')) { i++; continue }
+    break
+  }
+  return { italic: words.slice(0, i).join(' '), plain: words.slice(i).join(' ') }
+}
+
+const subjectParsed = computed(() =>
+  typeDesignation.value.subject_name ? splitName(typeDesignation.value.subject_name) : null
+)
+const objectParsed = computed(() =>
+  typeDesignation.value.object_name ? splitName(typeDesignation.value.object_name) : null
+)
+
+function escHtml(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+// Build the suffix as an HTML string to avoid Vue whitespace condensing stripping spaces.
+const labelSuffix = computed(() => {
+  const parts = []
+  if (subjectParsed.value?.plain) parts.push(escHtml(subjectParsed.value.plain))
+  if (typeDesignation.value.subject_status_tag) parts.push(escHtml(typeDesignation.value.subject_status_tag))
+  if (objectParsed.value) {
+    const { italic, plain } = objectParsed.value
+    const obj = objectItalic.value
+      ? `<em>${escHtml(italic)}</em>${plain ? ' ' + escHtml(plain) : ''}`
+      : `${escHtml(italic)}${plain ? ' ' + escHtml(plain) : ''}`
+    parts.push(obj)
+  }
+  return parts.length ? ' ' + parts.join(' ') : ''
+})
+
+// Resolve the OTU for the subject taxon name to build a link.
+const subjectOtuId = ref(null)
+
+watch(
+  () => typeDesignation.value.subject_taxon_name_id,
+  async (id) => {
+    subjectOtuId.value = null
+    if (!id) return
+    try {
+      const { data } = await makeAPIRequest.get('/otus', {
+        params: { 'taxon_name_id[]': id, per: 1 }
+      })
+      subjectOtuId.value = data[0]?.id ?? null
+    } catch { /* leave unlinked */ }
+  },
+  { immediate: true }
 )
 </script>


### PR DESCRIPTION
The "Type" panel is broken for anything except species-group names because of API changes. See the screenshot: The "Type" panel does not show anything, while the "Nomenclature" panel correctly displays the type species of the genus.
<img width="781" height="423" alt="grafik" src="https://github.com/user-attachments/assets/a9f55bd4-313a-43b0-a5c0-3d3c0e5973bb" />

This fix adjusts for the current version of the API and also does some cosmetic fixes (the type taxon name is rendered in italics and links to the TaxonPage of the corresponding OTU)
<img width="783" height="446" alt="grafik" src="https://github.com/user-attachments/assets/dbee9dbc-8db2-4a77-8232-1e2aa83e5d63" />

I probably won't use the type panel anymore as everything is also displayed in "Nomenclature". But it is a useful panel and I tought the fix may be useful for some users.
