### PR TITLE
made URLs clickable for DOI in nomenclature references

### DIFF
--- a/src/modules/otus/components/Panel/PanelNomenclatureReferences/PanelReferenceRow.vue
+++ b/src/modules/otus/components/Panel/PanelNomenclatureReferences/PanelReferenceRow.vue
@@ -2,14 +2,14 @@
   <li class="border-b border-base-muted p-3 px-5">
     <span
       class="[&>a]:break-all block"
-      :title="stripHTML(reference)"
-      v-html="reference"
+      :title="reference"
+      v-html="sanitizeAndLinkifyHtml(reference)"
     />
   </li>
 </template>
 
 <script setup>
-import { stripHTML } from '../../../utils'
+import { sanitizeAndLinkifyHtml } from '@/utils'
 
 defineProps({
   reference: {


### PR DESCRIPTION
Basically the same fix as https://github.com/SpeciesFileGroup/taxonpages/pull/351, but for the "Nomenclature References" panel. Makes the DOI URL clickable. 
Reusing convertUrlsToLinks from '@/modules/bibliography/utils'

Before (https://catalog.curculionoidea.org/#/otus/711541/overview):
<img width="784" height="159" alt="grafik" src="https://github.com/user-attachments/assets/ec3db1d0-d5c4-4533-ba3c-d96ef69d8285" />
After:
<img width="772" height="153" alt="grafik" src="https://github.com/user-attachments/assets/a1390448-2202-4b28-aa16-854b9e47dfe4" />

So far, to get clickable DOI URLs, I manually copied the DOI URL into the URL field in the "New source" task on TaxonWorks. This fix will save time, after importing a source via CrossRef it won't be necessary anymore to add something to the URL field.
<img width="1920" height="917" alt="grafik" src="https://github.com/user-attachments/assets/b2edef7c-8b72-4431-9973-39a4db635c18" />

